### PR TITLE
ci: serialize gh-pages deploys to prevent race on multi-chart releases

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: chart-release-gh-pages
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes this error when it's trying to update the Helm repo index:

```
Push the commit or tag
  [command]/usr/bin/git push origin gh-pages
  To https://github.com/open-cluster-management-io/helm-charts.git
   ! [rejected]        gh-pages -> gh-pages (fetch first)
  error: failed to push some refs to 'https://github.com/open-cluster-management-io/helm-charts.git'
  hint: Updates were rejected because the remote contains work that you do not
  hint: have locally. This is usually caused by another repository pushing to
  hint: the same ref. If you want to integrate the remote changes, use
  hint: 'git pull' before pushing again.
  hint: See the 'Note about fast-forwards' in 'git push --help' for details.
  Error: Action failed with "The process '/usr/bin/git' failed with exit code 1"
  ```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved chart release workflow handling to prevent overlapping releases from being canceled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->